### PR TITLE
Update commit hash for figures

### DIFF
--- a/content/10.methods.md
+++ b/content/10.methods.md
@@ -151,7 +151,7 @@ The countries associated with each grouping are shown in Fig {@fig:nameprism_cou
 NamePrism excluded the US, Canada and Australia because these countries have been populated by a mix of immigrant groups [@doi:10.1145/3132847.3133008].
 
 ![NamePrism groups countries by name similarity. We used this grouping but renamed the groups to focus on the linguistic patterns based on name etymology identified by NamePrism.
-](https://raw.githubusercontent.com/greenelab/iscb-diversity/286079d52a9ecc216f9e1364ec951e1c8dc09de8/figs/2020-01-31_groupings.png){#fig:nameprism_countries width="90%"}
+](https://raw.githubusercontent.com/greenelab/iscb-diversity/3853a20773764cedcf6aa61f38f062b26bd7655d/figs/2020-01-31_groupings.png){#fig:nameprism_countries width="90%"}
 
 In an earlier version of this manuscript, we also used category names derived from NamePrism, but a reader [pointed out](https://github.com/greenelab/iscb-diversity-manuscript/issues/27) the titles of the groupings were problematic;
 therefore, in this version, we renamed these groupings to reflect that the NamePrism approach primarily identifies groups based on linguistic patterns from name etymology rather than religious or racial similarities.

--- a/content/20.results.md
+++ b/content/20.results.md
@@ -32,7 +32,7 @@ Through 2019, there were a number of years when meetings or ISCB Fellow classes 
   all Pubmed computational biology and bioinformatics journal authors (left),
   and all ISCB Fellows and keynote speakers (right)
   was computed as the average of prediction probabilities of Pubmed articles or ISCB honorees each year.
-](https://raw.githubusercontent.com/greenelab/iscb-diversity/f43f7c40371343a4d8b91438b05c021fdb88af32/figs/gender_breakdown.png){#fig:gender_breakdown width="70%"}
+](https://raw.githubusercontent.com/greenelab/iscb-diversity/3853a20773764cedcf6aa61f38f062b26bd7655d/figs/gender_breakdown.png){#fig:gender_breakdown width="70%"}
 
 ### Predicting Name Origin Groups with LSTM Neural Networks and Wikipedia
 
@@ -78,7 +78,7 @@ Scaling by group prevalence accounts for the imbalance of groups in the testing 
 In all cases, the classifier predicts the true groups above the expected null probability (matrix diagonals are all purple).
 For off-diagonal cells, darker green indicates a lower mean prediction compared to the null.
 For example, the classifier does not often mistake East Asian names as Greek, but is more prone to mistaking South Asian names as Celtic/English.
-](https://raw.githubusercontent.com/greenelab/iscb-diversity/f43f7c40371343a4d8b91438b05c021fdb88af32/figs/fig_3.png){#fig:wiki2019_lstm width=100%}
+](https://raw.githubusercontent.com/greenelab/iscb-diversity/3853a20773764cedcf6aa61f38f062b26bd7655d/figs/fig_3.png){#fig:wiki2019_lstm width=100%}
 
 ### Assessing the Name Origin Diversity of Authors and Honorees
 
@@ -97,7 +97,7 @@ Estimated composition of name origin prediction over the years of
   was computed as the average of prediction probabilities of Pubmed articles or ISCB honorees each year.
   (B) For each region, the mean predicted probability of Pubmed articles is shown as teal LOESS curve, and the mean probability and 95% confidence interval of the ISCB honoree predictions are shown as dark circles and vertical lines.
 
-](https://raw.githubusercontent.com/greenelab/iscb-diversity/f43f7c40371343a4d8b91438b05c021fdb88af32/figs/region_breakdown.png){#fig:region_breakdown}
+](https://raw.githubusercontent.com/greenelab/iscb-diversity/3853a20773764cedcf6aa61f38f062b26bd7655d/figs/region_breakdown.png){#fig:region_breakdown}
 
 ### Affiliation Analysis
 
@@ -112,7 +112,7 @@ Each country's log~2~ enrichment (LOE) and its 95% confidence interval are displ
 Observed (triangle) and expected (circle) number of honorees and their differences (observed - expected) are shown in square-root scale on the right.
 Countries are ordered based on the proportion of authors in the field.
 
-](https://raw.githubusercontent.com/greenelab/iscb-diversity/a61b73ed80ba2062d31a1f111c1b8f388fda4b3a/figs/enrichment-plot.png){#fig:country-enrichment width="80%"}
+](https://raw.githubusercontent.com/greenelab/iscb-diversity/3853a20773764cedcf6aa61f38f062b26bd7655d/figs/enrichment-plot.png){#fig:country-enrichment width="80%"}
 
 | Country        | Author proportion | Observed | Expected | Observed - Expected | Enrichment | Log~2~(Enrichment) | 95% Confidence Interval |
 |----------------|-------------------|----------|----------|---------------------|------------|------------------|-------------------------|
@@ -162,7 +162,7 @@ Separating honoree results by honor category did not reveal any clear difference
   was computed as the average of prediction probabilities of Pubmed articles or ISCB honorees each year.
   For each race/ethnicity category, the mean predicted probability of Pubmed articles is shown as teal LOESS curve, and the mean probability and 95% confidence interval of the ISCB honoree predictions are shown as dark circles and vertical lines (E).
 
-](https://raw.githubusercontent.com/greenelab/iscb-diversity/f43f7c40371343a4d8b91438b05c021fdb88af32/figs/us_racial_makeup.png){#fig:us_racial_makeup}
+](https://raw.githubusercontent.com/greenelab/iscb-diversity/3853a20773764cedcf6aa61f38f062b26bd7655d/figs/us_racial_makeup.png){#fig:us_racial_makeup}
 
 We directly compared honoree and author results from 1993 to 2019 for the predicted proportion of white, Asian, and other categories (Fig. {@fig:us_racial_makeup}E).
 We found that, over the years, white honorees have been significantly overrepresented (t~218~ = 14.8, _p_ < 10^-16^) and Asian honorees have been significantly underrepresented (t~236~ = -18.8, _p_ < 10^-16^).
@@ -185,4 +185,4 @@ Estimated composition of name origin prediction over the years of
   was computed as the average of prediction probabilities of US-affiliated corresponding authors or ISCB honorees each year.
   (B) For each region, the mean predicted probability of US-affiliated corresponding authors is shown as teal LOESS curve, and the mean probability and 95% confidence interval of the US-affiliated ISCB honoree predictions are shown as dark circles and vertical lines.
 
-](https://raw.githubusercontent.com/greenelab/iscb-diversity/f43f7c40371343a4d8b91438b05c021fdb88af32/figs/us_name_origin.png){#fig:us_name_origin}
+](https://raw.githubusercontent.com/greenelab/iscb-diversity/3853a20773764cedcf6aa61f38f062b26bd7655d/figs/us_name_origin.png){#fig:us_name_origin}


### PR DESCRIPTION
Correct for the number of samples in calculating 95% CI in figures. Other statistics reported in the Results section stayed accurate (the same) because they were calculated separately. 