### PR TITLE
Re-include how bias relates to funding by topic

### DIFF
--- a/content/02.introduction.md
+++ b/content/02.introduction.md
@@ -15,6 +15,7 @@ There are also potential interaction effects between gender and race or ethnicit
 Another recent analysis found that minority scientists tend to apply for awards on topics with lower success rates [@doi:10.1126/sciadv.aaw7238].
 This finding might be the result of minority scientists selecting topics in more poorly funded areas.
 Alternatively, reviewing scientists may not recognize the scientific importance of these topics, which may be of particular interest to minority scientists.
+One way to address these competing hypotheses is to directly examine peer recognition.
 
 We sought to understand the extent to which honors and high-profile speaking invitations were distributed equitably among gender, race/ethnicity, and name origin groups by an international society and its associated meetings.
 As computational biologists, we focused on the [International Society for Computational Biology](https://www.iscb.org/) (ISCB), its honorary Fellows as well as its affiliated international meetings that aim to have a global reach: [Intelligent Systems for Molecular Biology](https://en.wikipedia.org/wiki/Intelligent_Systems_for_Molecular_Biology) (ISMB) and [Research in Computational Molecular Biology](https://en.wikipedia.org/wiki/Research_in_Computational_Molecular_Biology) (RECOMB).


### PR DESCRIPTION
This got removed in the reorganization. I think it is important to be clear that the reason we bring this up is because, if we find disparities, it supports a model where our decisions about the types of things we fund are also influenced by pernicious biases.